### PR TITLE
Update footer to automatically use the \manuscript parameter

### DIFF
--- a/review_response.tex
+++ b/review_response.tex
@@ -33,7 +33,7 @@
 \setcounter{page}{0}
 \pagestyle{fancy}
 \fancyfoot[R]{\thepage\ / \pageref{LastPage}}
-\fancyfoot[L]{Response Letter for TVCG-2023-X}
+\fancyfoot[L]{Response Letter for \manuscript}
 \fancyfoot[C]{\ }
 \input{Reviewers/Meta.tex}
 \input{Reviewers/R1.tex}


### PR DESCRIPTION
The footer should update to reflect the manuscript number, like the cover letter does.