### PR TITLE
Fix font color issue in breakable "changes" env

### DIFF
--- a/reviewresponse.sty
+++ b/reviewresponse.sty
@@ -113,7 +113,7 @@
 }{\vspace{1em}}
 
 \newenvironment{changes}{
-\begin{tcolorbox}[breakable,left skip=0em,enhanced jigsaw, colframe={colorchangebg}, coltext={colorchangetext}, boxrule=0.1em, leftrule=1.5em, opacityback=0, opacityframe=1, arc=0pt]
+\begin{tcolorbox}[breakable, left skip=0em, enhanced jigsaw, colframe={colorchangebg}, coltext={colorchangetext}, boxrule=0.1em, leftrule=1.5em, opacityback=0, opacityframe=1, arc=0pt]
 }
 {\end{tcolorbox}}
 

--- a/reviewresponse.sty
+++ b/reviewresponse.sty
@@ -113,7 +113,7 @@
 }{\vspace{1em}}
 
 \newenvironment{changes}{
-\begin{tcolorbox}[breakable,left skip=0em,enhanced jigsaw, colframe={colorchangebg}, boxrule=0.1em, leftrule=1.5em, opacityback=0, opacityframe=1, arc=0pt]\color{colorchangetext}
+\begin{tcolorbox}[breakable,left skip=0em,enhanced jigsaw, colframe={colorchangebg}, coltext={colorchangetext}, boxrule=0.1em, leftrule=1.5em, opacityback=0, opacityframe=1, arc=0pt]
 }
 {\end{tcolorbox}}
 


### PR DESCRIPTION
When a "changes" env breaks a page, the text color on the next page is reset to default. This PR fixes this issue.